### PR TITLE
add coroutines showing moving data in and out of coroutine

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,5 +8,7 @@ add_executable(task task.cpp)
 target_link_libraries(task PRIVATE CoroutineTests)
 add_executable(datasource datasource.cpp)
 target_link_libraries(datasource PRIVATE CoroutineTests)
+add_executable(datasink datasink.cpp)
+target_link_libraries(datasink PRIVATE CoroutineTests)
 
 add_executable(coroutines coroutines.cpp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,5 +6,7 @@ add_executable(lazy lazy.cpp)
 target_link_libraries(lazy PRIVATE CoroutineTests)
 add_executable(task task.cpp)
 target_link_libraries(task PRIVATE CoroutineTests)
+add_executable(datasource datasource.cpp)
+target_link_libraries(datasource PRIVATE CoroutineTests)
 
 add_executable(coroutines coroutines.cpp)

--- a/examples/datasink.cpp
+++ b/examples/datasink.cpp
@@ -1,0 +1,19 @@
+#include "CoroutineTests/datasink.hpp"
+
+#include <iostream>
+
+CoroutineTests::DataSink<int> example() {
+    while (true) {
+        auto x = co_await CoroutineTests::InputAwaiter<int>{};
+        std::cout << "Coroutine received: " << x << '\n';
+    }
+}
+
+int main() {
+    std::cout << "DataSink example:\n";
+    auto sink = example();
+    sink.put(42);
+    sink.put(1);
+    sink.put(-10);
+    return 0;
+}

--- a/examples/datasource.cpp
+++ b/examples/datasource.cpp
@@ -1,0 +1,20 @@
+#include "CoroutineTests/datasource.hpp"
+
+#include <iostream>
+
+CoroutineTests::DataSource<int> example() {
+    auto i = 0;
+    while (true) {
+        co_await CoroutineTests::OutputAwaiter{i++};
+    }
+}
+
+
+int main() {
+    std::cout << "DataSource example:\n";
+    auto source = example();
+    std::cout << "Got: " << source.get() << '\n';
+    std::cout << "Got: " << source.get() << '\n';
+    std::cout << "Got: " << source.get() << '\n';
+    return 0;
+}

--- a/include/CoroutineTests/datasink.hpp
+++ b/include/CoroutineTests/datasink.hpp
@@ -1,0 +1,86 @@
+#ifndef COROUTINETESTS_DATASINK_H
+#define COROUTINETESTS_DATASINK_H
+
+#include <coroutine>
+#include <exception>
+
+namespace CoroutineTests {
+
+template <typename T>
+class [[nodiscard]] DataSink {
+    public:
+    struct promise_type;  // typedef required by coroutines
+    using handle_type =
+        std::coroutine_handle<promise_type>;  // not required but useful
+
+    DataSink(handle_type coroutine_handle)
+        : m_coroutine(coroutine_handle) {}  // required by coroutines
+    ~DataSink() {
+        if (m_coroutine) {
+            m_coroutine.destroy();
+        }
+    }
+    DataSink() = default;
+    DataSink(const DataSink&) = delete;
+    DataSink& operator=(const DataSink&) = delete;
+    DataSink(DataSink&& other) noexcept : m_coroutine{other.m_coroutine} {
+        other.m_coroutine = {};
+    }
+    DataSink& operator=(DataSink&& other) noexcept {
+        if (this != &other) {
+            if (m_coroutine) {
+                m_coroutine.destroy();
+            }
+            m_coroutine = other.m_coroutine;
+            other.m_coroutine = {};
+        }
+        return *this;
+    }
+
+    void put(T value) {
+        if (m_coroutine && !m_coroutine.done()) {
+            m_coroutine.promise().current_input = value;
+            m_coroutine.resume();
+            if (m_coroutine.promise().exception) {
+                std::rethrow_exception(m_coroutine.promise().exception);
+            }
+        }
+    }
+
+    private:
+    handle_type m_coroutine;
+};
+
+template <typename T>
+struct DataSink<T>::promise_type {
+    std::exception_ptr exception;
+    T current_input{};
+
+    // required by coroutines
+    DataSink get_return_object() {
+        return {DataSink::handle_type::from_promise(*this)};
+    }
+    // called on coroutine start
+    std::suspend_never initial_suspend() {
+        return {};
+    }  // start immediately and follow to first co await
+    // called on coroutine completion
+    std::suspend_always final_suspend() noexcept { return {}; }
+    // acts as a catch block for exceptions thrown in the coroutine
+    void unhandled_exception() { exception = std::current_exception(); }
+    // called on (implicit or explicit) co_return or co_return_void
+    void return_void() {}
+};
+
+template <typename T>
+struct InputAwaiter {
+    using handle_type =
+        std::coroutine_handle<typename DataSink<T>::promise_type>;
+    handle_type m_coroutine;
+    bool await_ready() { return false; }
+    void await_suspend(handle_type h) { m_coroutine = h; }
+    T await_resume() { return m_coroutine.promise().current_input; }
+};
+
+}  // namespace CoroutineTests
+#endif  // COROUTINETESTS_DATASINK_H

--- a/include/CoroutineTests/datasink.hpp
+++ b/include/CoroutineTests/datasink.hpp
@@ -6,6 +6,8 @@
 
 namespace CoroutineTests {
 
+// Coroutine that receives data from outside.
+// Doesn't return a value, doesn't yield. Rethrows exceptions on put.
 template <typename T>
 class [[nodiscard]] DataSink {
     public:
@@ -36,7 +38,7 @@ class [[nodiscard]] DataSink {
         }
         return *this;
     }
-
+    // copy data to the coroutine and resume it
     void put(T value) {
         if (m_coroutine && !m_coroutine.done()) {
             m_coroutine.promise().current_input = value;
@@ -53,7 +55,9 @@ class [[nodiscard]] DataSink {
 
 template <typename T>
 struct DataSink<T>::promise_type {
+    // storage for exceptions thrown in the coroutine
     std::exception_ptr exception;
+    // storage for the latest value received from outside
     T current_input{};
 
     // required by coroutines
@@ -61,9 +65,8 @@ struct DataSink<T>::promise_type {
         return {DataSink::handle_type::from_promise(*this)};
     }
     // called on coroutine start
-    std::suspend_never initial_suspend() {
-        return {};
-    }  // start immediately and follow to first co await
+    // resume immediately and proceed to first co_await
+    std::suspend_never initial_suspend() { return {}; }
     // called on coroutine completion
     std::suspend_always final_suspend() noexcept { return {}; }
     // acts as a catch block for exceptions thrown in the coroutine
@@ -72,13 +75,19 @@ struct DataSink<T>::promise_type {
     void return_void() {}
 };
 
+// Simple await that allows to push data to the coroutine.
+// T received = co_await InputAwaiter<T>{};
 template <typename T>
 struct InputAwaiter {
     using handle_type =
         std::coroutine_handle<typename DataSink<T>::promise_type>;
+    // storage for the handle of a coroutine that suspended on co_await
     handle_type m_coroutine;
+    // don't resume immediately
     bool await_ready() { return false; }
+    // copy handle to the coroutine that suspended on co_await
     void await_suspend(handle_type h) { m_coroutine = h; }
+    // resume the coroutine and return the value taken from promise
     T await_resume() { return m_coroutine.promise().current_input; }
 };
 

--- a/include/CoroutineTests/datasource.hpp
+++ b/include/CoroutineTests/datasource.hpp
@@ -1,0 +1,90 @@
+#ifndef COROUTINETESTS_DATASOURCE_H
+#define COROUTINETESTS_DATASOURCE_H
+
+#include <coroutine>
+#include <exception>
+#include <stdexcept>
+
+namespace CoroutineTests {
+
+template <typename T>
+class [[nodiscard]] DataSource {
+    public:
+    struct promise_type;  // typedef required by coroutines
+    using handle_type =
+        std::coroutine_handle<promise_type>;  // not required but useful
+
+    DataSource(handle_type coroutine_handle)
+        : m_coroutine(coroutine_handle) {}  // required by coroutines
+    ~DataSource() {
+        if (m_coroutine) {
+            m_coroutine.destroy();
+        }
+    }
+    DataSource() = default;
+    DataSource(const DataSource&) = delete;
+    DataSource& operator=(const DataSource&) = delete;
+    DataSource(DataSource&& other) noexcept : m_coroutine{other.m_coroutine} {
+        other.m_coroutine = {};
+    }
+    DataSource& operator=(DataSource&& other) noexcept {
+        if (this != &other) {
+            if (m_coroutine) {
+                m_coroutine.destroy();
+            }
+            m_coroutine = other.m_coroutine;
+            other.m_coroutine = {};
+        }
+        return *this;
+    }
+
+    T get() {
+        if (m_coroutine) {
+            if (!m_coroutine.done()) {
+                m_coroutine.resume();
+                if (m_coroutine.promise().exception) {
+                    std::rethrow_exception(m_coroutine.promise().exception);
+                }
+            }
+            return m_coroutine.promise().current_output;
+        }
+        throw std::logic_error("get() called on an invalid coroutine handle");
+    }
+
+    private:
+    handle_type m_coroutine;
+};
+
+template <typename T>
+struct DataSource<T>::promise_type {
+    std::exception_ptr exception;
+    T current_output{};
+
+    // required by coroutines
+    DataSource get_return_object() {
+        return {DataSource::handle_type::from_promise(*this)};
+    }
+    // called on coroutine start
+    std::suspend_always initial_suspend() { return {}; }
+    // called on coroutine completion
+    std::suspend_always final_suspend() noexcept { return {}; }
+    // acts as a catch block for exceptions thrown in the coroutine
+    void unhandled_exception() { exception = std::current_exception(); }
+    // called on (implicit or explicit) co_return or co_return_void
+    void return_void() {}
+};
+
+template <typename T>
+struct OutputAwaiter {
+    OutputAwaiter(T value) : value(value) {}
+    T value;
+    bool await_ready() { return false; }
+    void await_suspend(
+        std::coroutine_handle<typename DataSource<T>::promise_type> h) {
+        h.promise().current_output = value;
+    }
+    void await_resume() {}
+};
+
+}  // namespace CoroutineTests
+#endif  // COROUTINETESTS_DATASOURCE_H

--- a/include/CoroutineTests/datasource.hpp
+++ b/include/CoroutineTests/datasource.hpp
@@ -7,6 +7,10 @@
 
 namespace CoroutineTests {
 
+// Coroutine that pushes data to outside.
+// Doesn't return a value, doesn't yield. Rethrows exceptions on get.
+// Effectively for producing data from the coroutine co_yield could be used, but
+// here a more generic approach using only co_await is exercised.
 template <typename T>
 class [[nodiscard]] DataSource {
     public:
@@ -37,7 +41,7 @@ class [[nodiscard]] DataSource {
         }
         return *this;
     }
-
+    // resume coroutine and get the value
     T get() {
         if (m_coroutine) {
             if (!m_coroutine.done()) {
@@ -57,7 +61,9 @@ class [[nodiscard]] DataSource {
 
 template <typename T>
 struct DataSource<T>::promise_type {
+    // storage for exceptions thrown in the coroutine
     std::exception_ptr exception;
+    // storage for the latest value to be pushed to outside
     T current_output{};
 
     // required by coroutines
@@ -74,15 +80,21 @@ struct DataSource<T>::promise_type {
     void return_void() {}
 };
 
+// Simple awaiter that allows to receive data from the coroutine.
+// co_await OutputAwaiter{some_value};
+// This could be potentially replaced by just co_yield
 template <typename T>
 struct OutputAwaiter {
     OutputAwaiter(T value) : value(value) {}
     T value;
+    // don't resume immediately
     bool await_ready() { return false; }
+    // copy data from awaiter to the promise of coroutine that suspended
     void await_suspend(
         std::coroutine_handle<typename DataSource<T>::promise_type> h) {
         h.promise().current_output = value;
     }
+    // nothing special on resume
     void await_resume() {}
 };
 


### PR DESCRIPTION
Adding:
- "datasink" - coroutine that can receive data during await
- "datasource" - coroutine that can produce data during await -  this is alternative to using `co_yield`