### PR TITLE
add coroutine skeleton, add missing `const` specifiers

### DIFF
--- a/coroutine_skeleton.hpp
+++ b/coroutine_skeleton.hpp
@@ -1,0 +1,116 @@
+#include <coroutine>
+
+// This file contains the skeletons for coroutine return type/interface,
+// coroutine promise type and awaitables, listing their customizations points.
+// The skeletons are not intended to be used as is, but rather as a starting
+// point for implementing coroutines and awaitables.
+
+// Skeleton for a coroutine return type/interface
+// `[[nodiscard]]` is used to avoid mistaking coroutine for a function and
+// dropping the ReturnType.
+class [[nodiscard]] ReturnType {
+    public:
+    // REQUIRED typedef or implementing `std::coroutine_traits`
+    // `typedef` to a coroutine promise type
+    struct promise_type;
+    using handle_type =
+        std::coroutine_handle<promise_type>;  // not required but useful
+    // REQUIRED
+    // construct `ReturnType` from a coroutine handle
+    ReturnType(handle_type coroutine_handle) : m_coroutine(coroutine_handle) {}
+    // coroutine handle isn't owning and destroy has to be called manually
+    ~ReturnType() {
+        if (m_coroutine) {
+            m_coroutine.destroy();
+        }
+    }
+    // remaining constructors and assignment operators:
+    // - use invalid coroutine handle by default
+    // - delete copy constructor and assignment operator as `ReturnType` is
+    // assumed to own the handle
+    // - move constructor and assignment operator to transfer ownership of the
+    // handle
+    ReturnType() = default;
+    ReturnType(const ReturnType&) = delete;
+    ReturnType& operator=(const ReturnType&) = delete;
+    ReturnType(ReturnType&& other) noexcept : m_coroutine{other.m_coroutine} {
+        other.m_coroutine = {};
+    }
+    ReturnType& operator=(ReturnType&& other) noexcept {
+        if (this != &other) {
+            if (m_coroutine) {
+                m_coroutine.destroy();
+            }
+            m_coroutine = other.m_coroutine;
+            other.m_coroutine = {};
+        }
+        return *this;
+    }
+
+    private:
+    // non-owning handle to the coroutine storage/frame
+    handle_type m_coroutine;
+};
+
+// coroutine promise type used by the `ReturnType`
+struct ReturnType::promise_type {
+    // REQUIRED
+    // create `ReturnType`
+    ReturnType get_return_object() {
+        return {ReturnType::handle_type::from_promise(*this)};
+    }
+    // REQUIRED
+    // called on coroutine start, then implicitly `co_await` the retuned value
+    /*awaitable*/ initial_suspend();
+    // REQUIRED
+    // called on coroutine completion, then implicitly `co_await` the retuned
+    // value
+    /*awaitable*/ final_suspend();
+    // REQUIRED
+    // implicitly acts as a catch block for exceptions thrown in the coroutine
+    void unhandled_exception();
+
+    // REQUIRED either return_void or return_value
+    // called on (implicit or explicit) `co_return` or `co_return void`.
+    // Conflicts with `return_value` declaration
+    void return_void();
+    // called on `co_return value` if `value` isn't `void`. Conflicts with
+    // `return_void` declaration
+    /*value type*/ return_value();
+
+    // called on `co_yield value`, then `co_await` the returned value
+    /*awaitable*/ yield_value(/*value type*/);
+
+    // called on `co_await value`, transform `value` to awaitable then
+    // `co_await` it. Not used for implicit `co_await` in `initial_suspend`,
+    // `final_suspend`, `co_yield`
+    // alternatively an awaitable can implement `operator co_await`
+    /*awaitable*/ await_transform(/*value type*/);
+};
+
+// Skeleton of awaitable type
+// coroutine return type/interface can also implement the awaitable interface to
+// act as an awaitable
+struct Awaitable {
+    // REQUIRED
+    // optimization point to skip suspending the coroutine
+    bool await_ready() const { return false; }
+    // REQUIRED
+    // gets handle to coroutine that is about to be suspended then decides where
+    // to continue the handle can be either type erased
+    // `std::coroutine_handle<>` or specialized returned type/value are used to
+    // control the continuation:
+    // - `void` - suspend the coroutine and return control to the caller
+    // - `true` - suspend the coroutine and return control to the caller (same
+    // as `void`)
+    // - `false` - resume the coroutine that was to be suspended
+    // - `std::coroutine_handle` - suspend the coroutine and resume returned
+    // coroutine
+    // - `std::noop_coroutine_handle` - suspend the coroutine and return control
+    // to the caller (same as `void`)
+    /* void or bool or std::coroutine_handle*/ await_suspend(handle_type h);
+    // REQUIRED
+    // resume the suspended coroutine and return the value, e.g.
+    // `auto value = co_await Awaitable{};`
+    /*value type*/ await_resume();
+};

--- a/include/CoroutineTests/datasink.hpp
+++ b/include/CoroutineTests/datasink.hpp
@@ -39,7 +39,7 @@ class [[nodiscard]] DataSink {
         return *this;
     }
     // copy data to the coroutine and resume it
-    void put(T value) {
+    void put(T value) const {
         if (m_coroutine && !m_coroutine.done()) {
             m_coroutine.promise().current_input = value;
             m_coroutine.resume();
@@ -66,13 +66,13 @@ struct DataSink<T>::promise_type {
     }
     // called on coroutine start
     // resume immediately and proceed to first co_await
-    std::suspend_never initial_suspend() { return {}; }
+    std::suspend_never initial_suspend() const { return {}; }
     // called on coroutine completion
-    std::suspend_always final_suspend() noexcept { return {}; }
+    std::suspend_always final_suspend() const noexcept { return {}; }
     // acts as a catch block for exceptions thrown in the coroutine
     void unhandled_exception() { exception = std::current_exception(); }
     // called on (implicit or explicit) co_return or co_return_void
-    void return_void() {}
+    void return_void() const {}
 };
 
 // Simple await that allows to push data to the coroutine.
@@ -84,11 +84,11 @@ struct InputAwaiter {
     // storage for the handle of a coroutine that suspended on co_await
     handle_type m_coroutine;
     // don't resume immediately
-    bool await_ready() { return false; }
+    bool await_ready() const { return false; }
     // copy handle to the coroutine that suspended on co_await
     void await_suspend(handle_type h) { m_coroutine = h; }
     // resume the coroutine and return the value taken from promise
-    T await_resume() { return m_coroutine.promise().current_input; }
+    T await_resume() const { return m_coroutine.promise().current_input; }
 };
 
 }  // namespace CoroutineTests

--- a/include/CoroutineTests/datasource.hpp
+++ b/include/CoroutineTests/datasource.hpp
@@ -42,7 +42,7 @@ class [[nodiscard]] DataSource {
         return *this;
     }
     // resume coroutine and get the value
-    T get() {
+    T get() const {
         if (m_coroutine) {
             if (!m_coroutine.done()) {
                 m_coroutine.resume();
@@ -71,13 +71,13 @@ struct DataSource<T>::promise_type {
         return {DataSource::handle_type::from_promise(*this)};
     }
     // called on coroutine start
-    std::suspend_always initial_suspend() { return {}; }
+    std::suspend_always initial_suspend() const { return {}; }
     // called on coroutine completion
-    std::suspend_always final_suspend() noexcept { return {}; }
+    std::suspend_always final_suspend() const noexcept { return {}; }
     // acts as a catch block for exceptions thrown in the coroutine
     void unhandled_exception() { exception = std::current_exception(); }
     // called on (implicit or explicit) co_return or co_return_void
-    void return_void() {}
+    void return_void() const {}
 };
 
 // Simple awaiter that allows to receive data from the coroutine.
@@ -88,14 +88,14 @@ struct OutputAwaiter {
     OutputAwaiter(T value) : value(value) {}
     T value;
     // don't resume immediately
-    bool await_ready() { return false; }
+    bool await_ready() const { return false; }
     // copy data from awaiter to the promise of coroutine that suspended
     void await_suspend(
         std::coroutine_handle<typename DataSource<T>::promise_type> h) {
         h.promise().current_output = value;
     }
     // nothing special on resume
-    void await_resume() {}
+    void await_resume() const {}
 };
 
 }  // namespace CoroutineTests

--- a/include/CoroutineTests/generator.hpp
+++ b/include/CoroutineTests/generator.hpp
@@ -10,10 +10,10 @@ namespace CoroutineTests {
 // Simple generator that yields values of type T.
 // The generator is a range and can be used in range-based for loops or standard
 // algorithms.
-// Doesn't support co_await inside the coroutine or nesting of coroutines. Uses
-// default memory allocation.
+// Uses default memory allocation.
 template <typename T>
-class [[nodiscard]] Generator : public std::ranges::view_interface<Generator<T>> {
+class [[nodiscard]] Generator
+    : public std::ranges::view_interface<Generator<T>> {
     public:
     struct promise_type;  // typedef required by coroutines
     using handle_type =
@@ -44,14 +44,14 @@ class [[nodiscard]] Generator : public std::ranges::view_interface<Generator<T>>
     }
 
     // begin and end required by view_interface
-    struct Iter;
-    Iter begin() {
+    class Iter;
+    Iter begin() const {
         if (m_coroutine) {
             m_coroutine.resume();
         }
         return Iter{m_coroutine};
     }
-    std::default_sentinel_t end() { return {}; }
+    std::default_sentinel_t end() const { return {}; }
 
     private:
     handle_type m_coroutine;
@@ -66,16 +66,14 @@ struct Generator<T>::promise_type {
         return {Generator<T>::handle_type::from_promise(*this)};
     }
     // called on coroutine start
-    std::suspend_always initial_suspend() { return {}; }
+    std::suspend_always initial_suspend() const { return {}; }
     // called on coroutine completion
-    std::suspend_always final_suspend() noexcept { return {}; }
+    std::suspend_always final_suspend() const noexcept { return {}; }
     // called on co_yield
     std::suspend_always yield_value(T value) {
         current_value = std::move(value);
         return {};
     }
-    // disable co_await inside coroutine
-    void await_transform() = delete;
     // called on (implicit or explicit) co_return or co_return_void
     void return_void() {}
     // acts as a catch block for exceptions thrown in the coroutine
@@ -95,7 +93,7 @@ class Generator<T>::Iter {
     explicit Iter(const Generator<T>::handle_type coroutine)
         : m_coroutine{coroutine} {}
 
-        // Resume the coroutine and check if exception was thrown
+    // Resume the coroutine and check if exception was thrown
     Iter& operator++() {
         m_coroutine.resume();
         if (m_coroutine.promise().exception) {

--- a/include/CoroutineTests/lazy.hpp
+++ b/include/CoroutineTests/lazy.hpp
@@ -9,7 +9,7 @@ namespace CoroutineTests {
 namespace detail {
 
 // Simple coroutine wrapper that returns a value lazily or eagerly.
-// Co await and co yield are disabled, only co return is allowed.
+// co_yield is disabled, only co_return is allowed.
 // No custom allocator is used. Exceptions are caught and rethrown.
 template <typename T, bool is_lazy>
 class [[nodiscard]] MaybeLazy {
@@ -43,7 +43,7 @@ class [[nodiscard]] MaybeLazy {
         return *this;
     }
 
-    T get() {
+    T get() const {
         if (!m_coroutine.done()) {
             m_coroutine.resume();
         }
@@ -67,7 +67,7 @@ struct MaybeLazy<T, is_lazy>::promise_type {
         return {MaybeLazy<T, is_lazy>::handle_type::from_promise(*this)};
     }
     // called on coroutine start
-    auto initial_suspend() {
+    auto initial_suspend() const {
         if constexpr (is_lazy) {
             return std::suspend_always{};  // suspend execution
         } else {
@@ -75,14 +75,12 @@ struct MaybeLazy<T, is_lazy>::promise_type {
         }
     }
     // called on coroutine completion
-    std::suspend_always final_suspend() noexcept { return {}; }
+    std::suspend_always final_suspend() const noexcept { return {}; }
     // called on co_yield
     std::suspend_always yield_value(T value) = delete;  // no co yield allowed
     // called on (implicit or explicit) co_return or co_return void. Conflicts
     // return_void.
     void return_value(T value) { current_value = std::move(value); }
-    // disable co_await inside coroutine
-    void await_transform() = delete;
     // acts as a catch block for exceptions thrown in the coroutine
     void unhandled_exception() { exception = std::current_exception(); }
 };

--- a/include/CoroutineTests/task.hpp
+++ b/include/CoroutineTests/task.hpp
@@ -38,14 +38,13 @@ class [[nodiscard]] Task {
         return *this;
     }
     // resume the coroutine from outside
-    inline void resume();
+    inline void resume() const;
     // check if finished from outside
     inline bool done() const { return m_coroutine.done(); }
 
     private:
     handle_type m_coroutine;
 };
-
 
 struct Task::promise_type {
     // storage for exceptions thrown in the coroutine
@@ -55,16 +54,16 @@ struct Task::promise_type {
         return {Task::handle_type::from_promise(*this)};
     }
     // called on coroutine start
-    std::suspend_always initial_suspend() { return {}; }
+    std::suspend_always initial_suspend() const { return {}; }
     // called on coroutine completion
-    std::suspend_always final_suspend() noexcept { return {}; }
+    std::suspend_always final_suspend() const noexcept { return {}; }
     // acts as a catch block for exceptions thrown in the coroutine
     void unhandled_exception() { exception = std::current_exception(); }
     // called on (implicit or explicit) co_return or co_return_void
-    void return_void() {}
+    void return_void() const {}
 };
 
-inline void Task::resume() {
+inline void Task::resume() const {
     if (!m_coroutine.done()) {
         m_coroutine.resume();
     }


### PR DESCRIPTION
Add skeletons of coroutine return type/interface, corutine promise type and awaitable - can be copied and filled with implementation

Some of the classes were missing some `const` specifiers