### PR TITLE
Add task that can be nested

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,5 +10,7 @@ add_executable(datasource datasource.cpp)
 target_link_libraries(datasource PRIVATE CoroutineTests)
 add_executable(datasink datasink.cpp)
 target_link_libraries(datasink PRIVATE CoroutineTests)
+add_executable(nestabletask nestabletask.cpp)
+target_link_libraries(nestabletask PRIVATE CoroutineTests)
 
 add_executable(coroutines coroutines.cpp)

--- a/examples/nestabletask.cpp
+++ b/examples/nestabletask.cpp
@@ -1,0 +1,51 @@
+#include "CoroutineTests/nestabletask.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+struct AsyncMockup {
+    std::chrono::milliseconds delay;
+    bool await_ready() const noexcept { return false; }
+    void await_suspend(std::coroutine_handle<> handle) const noexcept {
+        std::thread([delay = delay, handle]() {
+            std::this_thread::sleep_for(delay);
+            std::cout << "AsyncMockup done\n";
+            handle.resume();
+        }).detach();
+    }
+    void await_resume() const noexcept {}
+};
+
+CoroutineTests::NestableTask inner_task() {
+    std::cout << "Inner task resumed 0\n";
+    co_await AsyncMockup{std::chrono::milliseconds(2500)};
+    std::cout << "Inner task resumed 1\n";
+    co_await AsyncMockup{std::chrono::milliseconds(1500)};
+    std::cout << "Inner task resumed 2\n";
+    co_return;
+}
+
+CoroutineTests::NestableTask middle_task() {
+    std::cout << "Middle task resumed 0\n";
+    co_await inner_task();
+    std::cout << "Middle task resumed 1\n";
+}
+
+CoroutineTests::NestableTask outer_task() {
+    std::cout << "Outer task resumed 0\n";
+    co_await middle_task();
+    std::cout << "Outer task resumed 1\n";
+}
+
+int main() {
+    std::cout << "Lazy evaluation example:\n";
+    auto outer = outer_task();
+    outer.resume();
+    while(!outer.done()) {
+        std::cout << "."<<std::flush;
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+    std::cout << "Outer task done!\n";
+    return 0;
+}

--- a/include/CoroutineTests/nestabletask.hpp
+++ b/include/CoroutineTests/nestabletask.hpp
@@ -1,0 +1,111 @@
+#ifndef COROUTINETESTS_NESTABLETASK_H
+#define COROUTINETESTS_NESTABLETASK_H
+
+#include <coroutine>
+#include <exception>
+
+namespace CoroutineTests {
+
+// Coroutine that can be nested and co_awaited on inside another coroutine.
+// Doesn't return a value, doesn't yield. Rethrows exceptions on resume.
+// The outer coroutine should be resumed from outside.
+class [[nodiscard]] NestableTask {
+    public:
+    struct promise_type;  // typedef required by coroutines
+    using handle_type =
+        std::coroutine_handle<promise_type>;  // not required but useful
+
+    NestableTask(handle_type coroutine_handle)
+        : m_coroutine(coroutine_handle) {}  // required by coroutines
+    ~NestableTask() {
+        if (m_coroutine) {
+            m_coroutine.destroy();
+        }
+    }
+    NestableTask() = default;
+    NestableTask(const NestableTask&) = delete;
+    NestableTask& operator=(const NestableTask&) = delete;
+    NestableTask(NestableTask&& other) noexcept
+        : m_coroutine{other.m_coroutine} {
+        other.m_coroutine = {};
+    }
+    NestableTask& operator=(NestableTask&& other) noexcept {
+        if (this != &other) {
+            if (m_coroutine) {
+                m_coroutine.destroy();
+            }
+            m_coroutine = other.m_coroutine;
+            other.m_coroutine = {};
+        }
+        return *this;
+    }
+    // resume the coroutine from outside
+    inline void resume() const;
+    // check if finished from outside
+    inline bool done() const { return m_coroutine.done(); }
+
+    // awaitable interface
+    // don't skip suspensions
+    bool await_ready() const noexcept { return false; }
+    // when awaited, store the parent coroutine handle and resume this coroutine
+    inline auto await_suspend(handle_type handle) noexcept;
+    // nothing special on resume, doesn't produce a value
+    void await_resume() const noexcept {}
+
+    private:
+    handle_type m_coroutine;
+};
+
+struct NestableTask::promise_type {
+    // storage for exceptions thrown in the coroutine
+    std::exception_ptr exception;
+    // required by coroutines
+    NestableTask get_return_object() {
+        return {NestableTask::handle_type::from_promise(*this)};
+    }
+    // called on coroutine start
+    std::suspend_always initial_suspend() const { return {}; }
+    // called on coroutine completion
+    // on final_suspend return control to the parent coroutine
+    auto final_suspend() const noexcept {
+        struct final_awaiter {
+            // don't skip suspensions
+            bool await_ready() const noexcept { return false; }
+            // resume the parent of the suspended coroutine if it has one
+            // or if not then continue control to the caller
+            std::coroutine_handle<> await_suspend(handle_type handle) noexcept {
+                auto parent = handle.promise().m_parent;
+                if (parent) {
+                    return parent;
+                }
+                return std::noop_coroutine();
+            }
+            // nothing special on resume, doesn't produce a value
+            void await_resume() const noexcept {}
+        };
+        return final_awaiter{};
+    }
+    // acts as a catch block for exceptions thrown in the coroutine
+    void unhandled_exception() { exception = std::current_exception(); }
+    // called on (implicit or explicit) co_return or co_return_void
+    void return_void() const {}
+    // handle to the parent coroutine if the coroutine has one
+    handle_type m_parent;
+};
+
+inline void NestableTask::resume() const {
+    if (!m_coroutine.done()) {
+        m_coroutine.resume();
+    }
+    if (m_coroutine.promise().exception) {
+        std::rethrow_exception(m_coroutine.promise().exception);
+    }
+}
+
+inline auto NestableTask::await_suspend(handle_type handle) noexcept {
+    m_coroutine.promise().m_parent = handle;
+    return m_coroutine;
+}
+
+}  // namespace CoroutineTests
+#endif  // COROUTINETESTS_NESTABLETASK_H


### PR DESCRIPTION
Add `NestableTask` - an example of coroutine that can be `co_awaited` inside another coroutine. On `co_await` the parent will be suspended and child will get resumed, on child's `final_suspend` the parent will get resumed again.

In the example there is also a crude example awaiter that pretends to be a 3-rd party asynchronous API using callback - the callback will resume the function that was suspended on this awaiter.

One thing that is missing is error handling after the tasks were suspended