### PR TITLE
Add example using "event" for synchronization

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,5 +12,7 @@ add_executable(datasink datasink.cpp)
 target_link_libraries(datasink PRIVATE CoroutineTests)
 add_executable(nestabletask nestabletask.cpp)
 target_link_libraries(nestabletask PRIVATE CoroutineTests)
+add_executable(event event.cpp)
+target_link_libraries(event PRIVATE CoroutineTests)
 
 add_executable(coroutines coroutines.cpp)

--- a/examples/event.cpp
+++ b/examples/event.cpp
@@ -1,0 +1,31 @@
+#include "CoroutineTests/event.hpp"
+
+#include <iostream>
+
+#include "CoroutineTests/nestabletask.hpp"
+
+CoroutineTests::NestableTask example_task(SimpleEvent& event) {
+    std::cout << "Task resumed 0\n";
+    co_await event;
+    std::cout << "Task resumed 1\n";
+}
+
+CoroutineTests::NestableTask another_task(SimpleEvent& event) {
+    std::cout << "Another task resumed 0\n";
+    co_await event;
+    std::cout << "Another task resumed 1\n";
+    co_await event;
+    std::cout << "Another task resumed 2\n";
+}
+
+int main() {
+    std::cout << "Event example:\n";
+    SimpleEvent event;
+    auto task = example_task(event);
+    auto another = another_task(event);
+    task.resume();
+    another.resume();
+    std::cout << "Setting event\n";
+    event.set();
+    return 0;
+}

--- a/examples/nestabletask.cpp
+++ b/examples/nestabletask.cpp
@@ -39,7 +39,7 @@ CoroutineTests::NestableTask outer_task() {
 }
 
 int main() {
-    std::cout << "Lazy evaluation example:\n";
+    std::cout << "Nested tasks example example:\n";
     auto outer = outer_task();
     outer.resume();
     while(!outer.done()) {

--- a/include/CoroutineTests/event.hpp
+++ b/include/CoroutineTests/event.hpp
@@ -1,0 +1,50 @@
+#include <coroutine>
+#include <deque>
+
+#include "CoroutineTests/nestabletask.hpp"
+
+// Synchronization event. Can be awaited by multiple coroutines. Can be set once
+// to resume all the coroutines suspended on it. Coroutines awaiting event that
+// was already set will resume immediately.
+class SimpleEvent {
+    public:
+    void set() {
+        if (!m_awaiter.m_ready) {
+            m_awaiter.m_ready = true;
+            for (auto& handle : m_awaiter.m_handles) {
+                if (handle && !handle.done()) {
+                    handle.resume();
+                    if (handle.promise().exception) {
+                        std::rethrow_exception(handle.promise().exception);
+                    }
+                }
+                m_awaiter.m_handles.clear();
+            }
+        }
+    }
+
+    auto& operator co_await() { return m_awaiter; }
+
+    private:
+    // If not ready stashes awaiting coroutines and return control to the
+    // caller. If ready immediately resume awaiting coroutine.
+    struct Awaiter {
+        bool await_ready() const noexcept { return false; }
+        std::coroutine_handle<> await_suspend(
+            std::coroutine_handle<CoroutineTests::NestableTask::promise_type>
+                handle) noexcept {
+            if (m_ready) {
+                return handle;
+            }
+            m_handles.push_back(handle);
+            return std::noop_coroutine();
+        }
+        void await_resume() const noexcept {}
+
+        std::deque<
+            std::coroutine_handle<CoroutineTests::NestableTask::promise_type>>
+            m_handles;
+        bool m_ready{false};
+    };
+    Awaiter m_awaiter;
+};


### PR DESCRIPTION
Adding `SimpleEvent` awaitable - multiple corotuines can await an event and will be resumed when the event is set. Coroutines awaiting already set event will resume immediately