### PR TITLE
add missing member prefixes

### DIFF
--- a/include/CoroutineTests/async.hpp
+++ b/include/CoroutineTests/async.hpp
@@ -58,7 +58,7 @@ class [[nodiscard]] Async {
 
 struct Async::promise_type {
     // storage for exceptions thrown in the coroutine
-    std::exception_ptr exception;
+    std::exception_ptr m_exception;
     // handle to the parent coroutine if the coroutine has one
     handle_type m_parent;
     // handle to the threadpool
@@ -96,7 +96,7 @@ struct Async::promise_type {
         return final_awaiter{};
     }
     // acts as a catch block for exceptions thrown in the coroutine
-    void unhandled_exception() { exception = std::current_exception(); }
+    void unhandled_exception() { m_exception = std::current_exception(); }
     // called on (implicit or explicit) co_return or co_return void
     void return_void() const {}
 };

--- a/include/CoroutineTests/datasink.hpp
+++ b/include/CoroutineTests/datasink.hpp
@@ -41,10 +41,10 @@ class [[nodiscard]] DataSink {
     // copy data to the coroutine and resume it
     void put(T value) const {
         if (m_coroutine && !m_coroutine.done()) {
-            m_coroutine.promise().current_input = value;
+            m_coroutine.promise().m_current_input = value;
             m_coroutine.resume();
-            if (m_coroutine.promise().exception) {
-                std::rethrow_exception(m_coroutine.promise().exception);
+            if (m_coroutine.promise().m_exception) {
+                std::rethrow_exception(m_coroutine.promise().m_exception);
             }
         }
     }
@@ -56,9 +56,9 @@ class [[nodiscard]] DataSink {
 template <typename T>
 struct DataSink<T>::promise_type {
     // storage for exceptions thrown in the coroutine
-    std::exception_ptr exception;
+    std::exception_ptr m_exception;
     // storage for the latest value received from outside
-    T current_input{};
+    T m_current_input{};
 
     // required by coroutines
     DataSink get_return_object() {
@@ -70,7 +70,7 @@ struct DataSink<T>::promise_type {
     // called on coroutine completion
     std::suspend_always final_suspend() const noexcept { return {}; }
     // acts as a catch block for exceptions thrown in the coroutine
-    void unhandled_exception() { exception = std::current_exception(); }
+    void unhandled_exception() { m_exception = std::current_exception(); }
     // called on (implicit or explicit) co_return or co_return void
     void return_void() const {}
 };
@@ -88,7 +88,7 @@ struct InputAwaiter {
     // copy handle to the coroutine that suspended on co_await
     void await_suspend(handle_type h) { m_coroutine = h; }
     // resume the coroutine and return the value taken from promise
-    T await_resume() const { return m_coroutine.promise().current_input; }
+    T await_resume() const { return m_coroutine.promise().m_current_input; }
 };
 
 }  // namespace CoroutineTests

--- a/include/CoroutineTests/datasource.hpp
+++ b/include/CoroutineTests/datasource.hpp
@@ -46,11 +46,11 @@ class [[nodiscard]] DataSource {
         if (m_coroutine) {
             if (!m_coroutine.done()) {
                 m_coroutine.resume();
-                if (m_coroutine.promise().exception) {
-                    std::rethrow_exception(m_coroutine.promise().exception);
+                if (m_coroutine.promise().m_exception) {
+                    std::rethrow_exception(m_coroutine.promise().m_exception);
                 }
             }
-            return m_coroutine.promise().current_output;
+            return m_coroutine.promise().m_current_output;
         }
         throw std::logic_error("get() called on an invalid coroutine handle");
     }
@@ -62,9 +62,9 @@ class [[nodiscard]] DataSource {
 template <typename T>
 struct DataSource<T>::promise_type {
     // storage for exceptions thrown in the coroutine
-    std::exception_ptr exception;
+    std::exception_ptr m_exception;
     // storage for the latest value to be pushed to outside
-    T current_output{};
+    T m_current_output{};
 
     // required by coroutines
     DataSource get_return_object() {
@@ -75,7 +75,7 @@ struct DataSource<T>::promise_type {
     // called on coroutine completion
     std::suspend_always final_suspend() const noexcept { return {}; }
     // acts as a catch block for exceptions thrown in the coroutine
-    void unhandled_exception() { exception = std::current_exception(); }
+    void unhandled_exception() { m_exception = std::current_exception(); }
     // called on (implicit or explicit) co_return or co_return void
     void return_void() const {}
 };
@@ -85,14 +85,14 @@ struct DataSource<T>::promise_type {
 // This could be potentially replaced by just co_yield
 template <typename T>
 struct OutputAwaiter {
-    OutputAwaiter(T value) : value(value) {}
-    T value;
+    OutputAwaiter(T value) : m_value(value) {}
+    T m_value;
     // don't resume immediately
     bool await_ready() const { return false; }
     // copy data from awaiter to the promise of coroutine that suspended
     void await_suspend(
         std::coroutine_handle<typename DataSource<T>::promise_type> h) {
-        h.promise().current_output = value;
+        h.promise().m_current_output = m_value;
     }
     // nothing special on resume
     void await_resume() const {}

--- a/include/CoroutineTests/event.hpp
+++ b/include/CoroutineTests/event.hpp
@@ -14,8 +14,8 @@ class SimpleEvent {
             for (auto& handle : m_awaiter.m_handles) {
                 if (handle && !handle.done()) {
                     handle.resume();
-                    if (handle.promise().exception) {
-                        std::rethrow_exception(handle.promise().exception);
+                    if (handle.promise().m_exception) {
+                        std::rethrow_exception(handle.promise().m_exception);
                     }
                 }
                 m_awaiter.m_handles.clear();

--- a/include/CoroutineTests/generator.hpp
+++ b/include/CoroutineTests/generator.hpp
@@ -59,8 +59,8 @@ class [[nodiscard]] Generator
 
 template <typename T>
 struct Generator<T>::promise_type {
-    T current_value;
-    std::exception_ptr exception;
+    T m_current_value;
+    std::exception_ptr m_exception;
     // required by coroutines
     Generator<T> get_return_object() {
         return {Generator<T>::handle_type::from_promise(*this)};
@@ -71,13 +71,13 @@ struct Generator<T>::promise_type {
     std::suspend_always final_suspend() const noexcept { return {}; }
     // called on co_yield
     std::suspend_always yield_value(T value) {
-        current_value = std::move(value);
+        m_current_value = std::move(value);
         return {};
     }
     // called on (implicit or explicit) co_return or co_return void
     void return_void() {}
     // acts as a catch block for exceptions thrown in the coroutine
-    void unhandled_exception() { exception = std::current_exception(); }
+    void unhandled_exception() { m_exception = std::current_exception(); }
 };
 
 template <typename T>
@@ -96,8 +96,8 @@ class Generator<T>::Iter {
     // Resume the coroutine and check if exception was thrown
     Iter& operator++() {
         m_coroutine.resume();
-        if (m_coroutine.promise().exception) {
-            std::rethrow_exception(m_coroutine.promise().exception);
+        if (m_coroutine.promise().m_exception) {
+            std::rethrow_exception(m_coroutine.promise().m_exception);
         }
         return *this;
     }
@@ -108,9 +108,9 @@ class Generator<T>::Iter {
         return temp;
     }
     // Return the current value of the coroutine
-    reference operator*() const { return m_coroutine.promise().current_value; }
+    reference operator*() const { return m_coroutine.promise().m_current_value; }
     pointer operator->() const {
-        return &(m_coroutine.promise().current_value);
+        return &(m_coroutine.promise().m_current_value);
     }
 
     bool operator==(std::default_sentinel_t) const {

--- a/include/CoroutineTests/lazy.hpp
+++ b/include/CoroutineTests/lazy.hpp
@@ -28,8 +28,7 @@ class [[nodiscard]] MaybeLazy {
     MaybeLazy() = default;
     MaybeLazy(const MaybeLazy&) = delete;
     MaybeLazy& operator=(const MaybeLazy&) = delete;
-    MaybeLazy(MaybeLazy&& other) noexcept
-        : m_coroutine{other.m_coroutine} {
+    MaybeLazy(MaybeLazy&& other) noexcept : m_coroutine{other.m_coroutine} {
         other.m_coroutine = {};
     }
     MaybeLazy& operator=(MaybeLazy&& other) noexcept {
@@ -47,10 +46,10 @@ class [[nodiscard]] MaybeLazy {
         if (!m_coroutine.done()) {
             m_coroutine.resume();
         }
-        if (m_coroutine.promise().exception) {
-            std::rethrow_exception(m_coroutine.promise().exception);
+        if (m_coroutine.promise().m_exception) {
+            std::rethrow_exception(m_coroutine.promise().m_exception);
         }
-        return m_coroutine.promise().current_value;
+        return m_coroutine.promise().m_current_value;
     }
     bool done() const { return m_coroutine.done(); }
 
@@ -60,8 +59,8 @@ class [[nodiscard]] MaybeLazy {
 
 template <typename T, bool is_lazy>
 struct MaybeLazy<T, is_lazy>::promise_type {
-    T current_value;
-    std::exception_ptr exception;
+    T m_current_value;
+    std::exception_ptr m_exception;
     // required by coroutines
     MaybeLazy<T, is_lazy> get_return_object() {
         return {MaybeLazy<T, is_lazy>::handle_type::from_promise(*this)};
@@ -80,9 +79,9 @@ struct MaybeLazy<T, is_lazy>::promise_type {
     std::suspend_always yield_value(T value) = delete;  // no co yield allowed
     // called on (implicit or explicit) co_return or co_return void. Conflicts
     // return_void.
-    void return_value(T value) { current_value = std::move(value); }
+    void return_value(T value) { m_current_value = std::move(value); }
     // acts as a catch block for exceptions thrown in the coroutine
-    void unhandled_exception() { exception = std::current_exception(); }
+    void unhandled_exception() { m_exception = std::current_exception(); }
 };
 }  // namespace detail
 

--- a/include/CoroutineTests/nestabletask.hpp
+++ b/include/CoroutineTests/nestabletask.hpp
@@ -58,7 +58,7 @@ class [[nodiscard]] NestableTask {
 
 struct NestableTask::promise_type {
     // storage for exceptions thrown in the coroutine
-    std::exception_ptr exception;
+    std::exception_ptr m_exception;
     // handle to the parent coroutine if the coroutine has one
     handle_type m_parent;
     // required by coroutines
@@ -88,7 +88,7 @@ struct NestableTask::promise_type {
         return final_awaiter{};
     }
     // acts as a catch block for exceptions thrown in the coroutine
-    void unhandled_exception() { exception = std::current_exception(); }
+    void unhandled_exception() { m_exception = std::current_exception(); }
     // called on (implicit or explicit) co_return or co_return void
     void return_void() const {}
 };
@@ -97,8 +97,8 @@ inline void NestableTask::resume() const {
     if (!m_coroutine.done()) {
         m_coroutine.resume();
     }
-    if (m_coroutine.promise().exception) {
-        std::rethrow_exception(m_coroutine.promise().exception);
+    if (m_coroutine.promise().m_exception) {
+        std::rethrow_exception(m_coroutine.promise().m_exception);
     }
 }
 

--- a/include/CoroutineTests/simplegenerator.hpp
+++ b/include/CoroutineTests/simplegenerator.hpp
@@ -44,8 +44,8 @@ class [[nodiscard]] SimpleGenerator {
         if (!m_coroutine.done()) {
             m_coroutine.resume();
         }
-        if (m_coroutine.promise().exception) {
-            std::rethrow_exception(m_coroutine.promise().exception);
+        if (m_coroutine.promise().m_exception) {
+            std::rethrow_exception(m_coroutine.promise().m_exception);
         }
         return m_coroutine.promise().m_value;
     }
@@ -59,7 +59,7 @@ class [[nodiscard]] SimpleGenerator {
 template <typename T>
 struct SimpleGenerator<T>::promise_type {
     // storage for exceptions thrown in the coroutine
-    std::exception_ptr exception;
+    std::exception_ptr m_exception;
     // yielded value
     T m_value{};
     // required by coroutines
@@ -71,7 +71,7 @@ struct SimpleGenerator<T>::promise_type {
     // called on coroutine completion
     std::suspend_always final_suspend() const noexcept { return {}; }
     // acts as a catch block for exceptions thrown in the coroutine
-    void unhandled_exception() { exception = std::current_exception(); }
+    void unhandled_exception() { m_exception = std::current_exception(); }
     // called on (implicit or explicit) co_return or co_return void
     void return_void() const {}
     std::suspend_always yield_value(T value) {

--- a/include/CoroutineTests/task.hpp
+++ b/include/CoroutineTests/task.hpp
@@ -48,7 +48,7 @@ class [[nodiscard]] Task {
 
 struct Task::promise_type {
     // storage for exceptions thrown in the coroutine
-    std::exception_ptr exception;
+    std::exception_ptr m_exception;
     // required by coroutines
     Task get_return_object() {
         return {Task::handle_type::from_promise(*this)};
@@ -58,7 +58,7 @@ struct Task::promise_type {
     // called on coroutine completion
     std::suspend_always final_suspend() const noexcept { return {}; }
     // acts as a catch block for exceptions thrown in the coroutine
-    void unhandled_exception() { exception = std::current_exception(); }
+    void unhandled_exception() { m_exception = std::current_exception(); }
     // called on (implicit or explicit) co_return or co_return void
     void return_void() const {}
 };
@@ -67,8 +67,8 @@ inline void Task::resume() const {
     if (!m_coroutine.done()) {
         m_coroutine.resume();
     }
-    if (m_coroutine.promise().exception) {
-        std::rethrow_exception(m_coroutine.promise().exception);
+    if (m_coroutine.promise().m_exception) {
+        std::rethrow_exception(m_coroutine.promise().m_exception);
     }
 }
 


### PR DESCRIPTION
To be consistent adding missing `m_` prefixes for member variables