### PR TITLE
synchronize printouts

### DIFF
--- a/examples/logging_utils.hpp
+++ b/examples/logging_utils.hpp
@@ -3,14 +3,15 @@
 #include <format>
 #include <iostream>
 #include <string_view>
+#include <syncstream>
 #include <thread>
 
-static inline std::ostream& log() {
-    return std::cout << std::this_thread::get_id() << "  ";
+static inline auto log() {
+    return std::osyncstream(std::cout) << std::this_thread::get_id() << "  ";
 }
 
-static inline std::ostream& log(std::string_view self) {
-    return std::cout << std::this_thread::get_id() << "  " << self << "  ";
+static inline auto log(std::string_view self) {
+    return log() << self << "  ";
 }
 
 static inline std::string format_name(std::string_view parent,


### PR DESCRIPTION
Using `syncstream` to synchronize `log()` so the printouts from multiple threads don't overlap each other