### PR TITLE
silence false-positive warning in GCC 15, 16

### DIFF
--- a/examples/capy_delegate.cpp
+++ b/examples/capy_delegate.cpp
@@ -235,8 +235,18 @@ int main() {
                 status.at(i) = code;
                 done.count_down();
             };
+// silence false-positive warning about uninitialized variables in Capy
+// allocator, affected GCC 15, 16
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
             boost::capy::run_async(executor, result_handler)(reconstruct(
                 streams.at(i), delegation_thread, "event" + std::to_string(i)));
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
         }
         done.wait();
         for (auto& stream : streams) {

--- a/examples/capy_event_poll.cpp
+++ b/examples/capy_event_poll.cpp
@@ -270,9 +270,20 @@ int main() {
                 status.at(i) = code;
                 done.count_down();
             };
+
+// silence false-positive warning about uninitialized variables in Capy
+// allocator, affected GCC 15, 16
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
             boost::capy::run_async(executor, result_handler)(
                 reconstruct(streams.at(i), events.at(i), delegation_thread,
                             "event" + std::to_string(i)));
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
         }
         done.wait();
         for (std::size_t i = 0; i < streams.size(); ++i) {

--- a/examples/capy_reco.cpp
+++ b/examples/capy_reco.cpp
@@ -202,8 +202,17 @@ int main() {
                 status.at(i) = code;
                 done.count_down();
             };
+// silence false-positive warning about uninitialized variables in Capy
+// allocator, affected GCC 15, 16
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
             boost::capy::run_async(executor, result_handler)(
                 reconstruct(streams.at(i), "event" + std::to_string(i)));
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
         }
         done.wait();
         for (auto& stream : streams) {


### PR DESCRIPTION
Silencing warnings about maybe uninitialized capy allocator. This is a false-positive in more recent versions of gcc 