### PR TITLE
fix missing `CUDART_CB` in callbacks

### DIFF
--- a/examples/alien_stream_await.hpp
+++ b/examples/alien_stream_await.hpp
@@ -28,7 +28,7 @@ class StreamAwaitable {
     cudaError_t m_error = cudaSuccess;
 
     template <typename Promise>
-    static void resumption_callback(void* userData) {
+    static void CUDART_CB resumption_callback(void* userData) {
         auto handle = std::coroutine_handle<Promise>::from_address(userData);
         handle.promise().reschedule();
     }

--- a/examples/capy_stream_await.hpp
+++ b/examples/capy_stream_await.hpp
@@ -32,7 +32,7 @@ class StreamIoAwaitable {
     cudaError_t m_error = cudaSuccess;
     context m_context;
 
-    static void resumption_callback(void* userData) {
+    static void CUDART_CB resumption_callback(void* userData) {
         auto* ctx = static_cast<context*>(userData);
         ctx->env->executor.post(ctx->continuation);
     }

--- a/examples/exec_stream_await_sender.hpp
+++ b/examples/exec_stream_await_sender.hpp
@@ -56,7 +56,7 @@ class stream_await_sender::stream_await_operation {
     std::remove_cvref_t<Receiver> m_receiver;
     cudaStream_t m_stream;
 
-    static void callback(void* userData) {
+    static void CUDART_CB callback(void* userData) {
         auto& recv = *static_cast<Receiver*>(userData);
         execution::set_value(std::move(recv), cudaSuccess);
     }


### PR DESCRIPTION
Callbacks for `cudaLaunchHostFunc` and `cudaStreamAddCallback` (matters for Windows)